### PR TITLE
Fixes where mix of types resulted in non-random values

### DIFF
--- a/attack/knn.fixed/knn.fixed.go
+++ b/attack/knn.fixed/knn.fixed.go
@@ -78,7 +78,7 @@ func getMax(f []float64) (val float64, index int) {
 func initWeight(weight []float64) {
 	// as in alg_init_weight
 	for i := 0; i < FeatNum; i++ {
-		weight[i] = float64(rand.Intn(100)/100.0) + 0.5
+		weight[i] = rand.Float64() + 0.5
 	}
 }
 
@@ -208,7 +208,7 @@ func determineWeights(feat [][]float64, weight []float64, start, end int) {
 
 	for i := 0; i < FeatNum; i++ {
 		if weight[i] > 0 {
-			weight[i] *= 0.9 + float64(rand.Intn(100)/500.0)
+			weight[i] *= 0.9 + rand.float64()*0.2
 		}
 	}
 


### PR DESCRIPTION
In the two expressions changed in this commit, a mix of types--specifically
dividing a float64 by a larger int64--resulted in a non-random result because
the int64 type was 'preferred' and division on int64s is always rounded down
(floor). Thus, the first expression always evaluated to 0.5 and the second to
0.9.
