### PR TITLE
Fixes issue #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Extract the fixed features:
 
 Run the original attack:
 
-    $ go run src/attacks/knn.orig/knn.orig.go
+    $ go run src/attack/knn.orig/knn.orig.go
     2016/04/12 11:32:49 loaded instances: main
     2016/04/12 11:32:50 loaded instances: training
     2016/04/12 11:32:52 loaded instances: testing
@@ -47,7 +47,7 @@ Run the original attack:
 
 Run the fixed attack:
 
-    $ go run src/attacks/knn.fixed/knn.fixed.go 
+    $ go run src/attack/knn.fixed/knn.fixed.go 
     2016/04/12 11:32:45 loaded instances: main
     2016/04/12 11:32:46 loaded instances: training
     2016/04/12 11:32:46 loaded instances: testing

--- a/attack/knn.fixed/knn.fixed.go
+++ b/attack/knn.fixed/knn.fixed.go
@@ -208,7 +208,7 @@ func determineWeights(feat [][]float64, weight []float64, start, end int) {
 
 	for i := 0; i < FeatNum; i++ {
 		if weight[i] > 0 {
-			weight[i] *= 0.9 + rand.float64()*0.2
+			weight[i] *= 0.9 + rand.Float64()*0.2
 		}
 	}
 


### PR DESCRIPTION
There shouldn't be an overlap between the test and training sets. This fix declares a new constant `TrainNum` which corresponds to the number of instances for each class used for training. `InstNum` has the meaning of _total number of instances for each class_. We also need to modify the functions to parse the files so to select different ranges of instances for training and testing.

As expected, we obtain slightly lower accuracy scores:

> 2016/08/10 20:44:15 starting to learn distance...
>         distance... 5999 (0-6000)
> 2016/08/10 20:45:45 finished
> 2016/08/10 20:45:45 started computing accuracy...
>         accuracy... 11999 (0-12000)
> 2016/08/10 20:52:29 finished
> 2016/08/10 20:52:29 Accuracy: 0.806667 0.993667
